### PR TITLE
[FIX] fix installer to instal the symbolic link in usr.local/bin

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -3,7 +3,7 @@ sudo rm -rf /usr/local/lib/mango
 sudo mkdir /usr/local/lib/mango
 sudo cp -r * /usr/local/lib/mango
 sudo chmod +x /usr/local/lib/mango/mango.py
-sudo ln -s /usr/local/lib/mango/mango.py /usr/bin/mango
+sudo ln -s /usr/local/lib/mango/mango.py /usr/local/bin/mango
 
 rm -rf ~/.mango
 mkdir ~/.mango


### PR DESCRIPTION
to put an external executable in usr/bin is dangerus and forbidden is some OS.